### PR TITLE
khronos_api 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/lib.rs"
 
 [build-dependencies]
 gl_generator = "0.4"
-khronos_api = "0.0"
+khronos_api = "1.0"
 
 [dependencies]
 gl_common = "0.1"


### PR DESCRIPTION
In an attempt to not have multiple versions of the same crate getting compiled (khronos_api 0.0.8 and 1.0.0), raised the version of khronos_api to "1.0".