### PR TITLE
Remove gl_common dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,3 @@ path = "src/lib.rs"
 [build-dependencies]
 gl_generator = "0.4"
 khronos_api = "1.0"
-
-[dependencies]
-gl_common = "0.1"


### PR DESCRIPTION
Situation is unclear but in an attempt to not have multiple versions of the same crate compile (libc 0.1.x and 0.2.x), removed the dependency on gl_common. On crates.io there is no repository listed for gl_common. It's unclear whether or not gl_common is still needed in this case after reading:
[https://github.com/bjz/gl-rs/pull/359 "Remove the gl_common crate #359"] (https://github.com/bjz/gl-rs/pull/359). gfx_gl still builds without it.